### PR TITLE
578: Move provision image into kubeless-config

### DIFF
--- a/docs/implementing-new-runtime.md
+++ b/docs/implementing-new-runtime.md
@@ -15,6 +15,7 @@ If you want to extend it and make another language available it is necessary to 
 
 ## 1. Update the kubeless-config configmap
 
+### Custom runtime images
 In this configmap there is a set of runtime images. You need to update this set with an entry pointing to the repository of the Docker container image for the runtime of the new language.
 
 Usually there are three entries - one for HTTP triggers, another for event based functions and another one for the Init container that will be used to install dependencies in the build process. If your new runtime implementation will support only HTTP triggers, then create only two entries as follows:
@@ -35,6 +36,16 @@ runtime-images
 +         depName: "requirements.xml"
 +         fileNameSuffix: ".cs"
 ``` 
+
+### Custom Provisioning container Images
+In the configmap there is a default provisioning container image. This image is used for init-container inside the function pods definition. One can specify a custom provisioning container by updating `provision-container-image` in the configmap
+
+```patch
+provision-container-image
+...
++ Image: "mycustom/provision/image:latest"
++ ImageSecret: "Secret"
+```
 
 Restart the controller after updating the configmap.
 

--- a/kubeless.jsonnet
+++ b/kubeless.jsonnet
@@ -150,11 +150,16 @@ local runtime_images ='[
   }
 ]';
 
+local provision_container_image = '{
+  Image: "kubeless/unzip@sha256:f162c062973cca05459834de6ed14c039d45df8cdb76097f50b028a1621b3697"
+}';
+
 local kubelessConfig  = configMap.default("kubeless-config", namespace) +
     configMap.data({"ingress-enabled": "false"}) +
     configMap.data({"service-type": "ClusterIP"})+
     configMap.data({"deployment": std.toString(deploymentConfig)})+
-    configMap.data({"runtime-images": std.toString(runtime_images)});
+    configMap.data({"runtime-images": std.toString(runtime_images)})+
+    configMap.data({"provision-container-image": std.toString(provision_container_image)});
 
 {
   controllerAccount: k.util.prune(controllerAccount),

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -251,7 +251,7 @@ func (c *Controller) ensureK8sResources(funcObj *kubelessApi.Function) error {
 		if err != nil {
 			return err
 		}
-		err = utils.EnsureFuncCronJob(restIface, funcObj, or, groupVersion)
+		err = utils.EnsureFuncCronJob(restIface, funcObj, or, groupVersion, c.langRuntime)
 		if err != nil {
 			return err
 		}

--- a/pkg/langruntime/langruntime_test.go
+++ b/pkg/langruntime/langruntime_test.go
@@ -161,13 +161,13 @@ func TestGetBuildContainer(t *testing.T) {
 		t.Errorf("Unexpected command %s", c.Args[0])
 	}
 
-	secrets, err := lr.GetImageSecrets("ruby2.4")
+	secrets, err := lr.GetAllSecrets("ruby2.4")
 	if err != nil {
 		t.Errorf("Unable to fetch secrets: %v", err)
 	}
 
-	if secrets[0].Name != "p1" && secrets[1].Name != "p2" {
-		t.Errorf("Expected first secret to be 'p1' but found %v and second secret to be 'p2' and found %v", secrets[0], secrets[1])
+	if secrets[0].Name != "p1" || secrets[1].Name != "p2" || secrets[2].Name != "p3" {
+		t.Errorf("Expected first secret to be 'p1' but found %v and second secret to be 'p2' and found %v and third secret to be 'p3' and found %v", secrets[0], secrets[1], secrets[2])
 	}
 
 }

--- a/pkg/langruntime/langruntimetestutils.go
+++ b/pkg/langruntime/langruntimetestutils.go
@@ -99,9 +99,19 @@ func AddFakeConfig(clientset *fake.Clientset) {
 		},
 	}}
 
-	out, err := yaml.Marshal(runtimeImages)
+	var provisionContainerImage = ProvisionContainerInfo{
+		Image:       "kubeless/unzip@sha256:f162c062973cca05459834de6ed14c039d45df8cdb76097f50b028a1621b3697",
+		ImageSecret: "p3",
+	}
+
+	runtimeImagesOut, err := yaml.Marshal(runtimeImages)
 	if err != nil {
 		logrus.Fatal("Canot Marshall runtimeimage")
+	}
+
+	provisionContainerImageOut, err := yaml.Marshal(provisionContainerImage)
+	if err != nil {
+		logrus.Fatal("Canot Marshall provision Container Image")
 	}
 
 	cm := v1.ConfigMap{
@@ -110,7 +120,8 @@ func AddFakeConfig(clientset *fake.Clientset) {
 			Namespace: "kubeless",
 		},
 		Data: map[string]string{
-			"runtime-images": string(out),
+			"runtime-images":            string(runtimeImagesOut),
+			"provision-container-image": string(provisionContainerImageOut),
 		},
 	}
 


### PR DESCRIPTION
- Allow the provisioning image used for init-image
  in Pods deployment to kuebless-config.
- This should allow users to define custom
  provisioning image.

**Issue Ref**: [Issue number related to this PR or None]
 
**Description**: 

[PR Description]

**TODOs**:
 - [ ] Ready to review
 - [ ] Automated Tests
 - [ ] Docs
